### PR TITLE
Fix typo in the deleting of `-o` flags

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -55,7 +55,7 @@ postconf -e "home_mailbox = Mail/Inbox/"
 
 echo "Configuring Postfix's master.cf..."
 
-sed -i "/^\s*o/d;/^\s*submission/d;/^\s*smtp/d" /etc/postfix/master.cf
+sed -i "/^\s*-o/d;/^\s*submission/d;/^\s*smtp/d" /etc/postfix/master.cf
 
 echo "smtp unix - - n - - smtp
 smtp inet n - y - - smtpd


### PR DESCRIPTION
Deleting all settings starting with o seems rather arbitrary, but I don't know the default configuration on Vultr, so could be warranted :) But I'll be bold and guess the `sed` command and the following lines are supposed to be related?