### PR TITLE
prevent false detection of opendkim KeyTable config

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -177,7 +177,7 @@ grep "127.0.0.1" >/dev/null 2>&1 /etc/postfix/dkim/trustedhosts ||
 1.2.3.4/24" >> /etc/postfix/dkim/trustedhosts
 
 # ...and source it from opendkim.conf
-grep KeyTable /etc/opendkim.conf >/dev/null || echo "KeyTable file:/etc/postfix/dkim/keytable
+grep ^KeyTable /etc/opendkim.conf >/dev/null || echo "KeyTable file:/etc/postfix/dkim/keytable
 SigningTable refile:/etc/postfix/dkim/signingtable
 InternalHosts refile:/etc/postfix/dkim/trustedhosts" >> /etc/opendkim.conf
 


### PR DESCRIPTION
default /etc/opendkim.conf has KeyTable appear in comment doco and example.
Shouldn't trigger the grep that checks whether this config has been applied.