### PR TITLE
close quotation marks in opendkim socket config

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -182,7 +182,7 @@ SigningTable refile:/etc/postfix/dkim/signingtable
 InternalHosts refile:/etc/postfix/dkim/trustedhosts" >> /etc/opendkim.conf
 
 # OpenDKIM daemon settings, removing previously activated socket.
-sed -i "/^SOCKET/d" /etc/default/opendkim && echo "SOCKET=\"inet:8891@localhost" >> /etc/default/opendkim
+sed -i "/^SOCKET/d" /etc/default/opendkim && echo "SOCKET=\"inet:8891@localhost\"" >> /etc/default/opendkim
 
 # Here we add to postconf the needed settings for working with OpenDKIM
 echo "Configuring Postfix with OpenDKIM settings..."


### PR DESCRIPTION
opendkim ignores the invalid SOCKET config line, causing smtpd mail send to fail.

```
$ sudo systemctl status opendkim
systemd[1]: Ignoring invalid environment assignment 'SOCKET=inet:8891@localhost
systemd[1]: ': /etc/sysconfig/opendkim

$ journalctl
postfix/submission/smtpd[17646]: fatal: host/service localhost/8891 not found: Device or resource busy
```