### PR TITLE
Fix TLS encrypted emails to Gmail

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -34,6 +34,9 @@ postconf -e "smtpd_tls_key_file=/etc/letsencrypt/live/$maildomain/privkey.pem"
 postconf -e "smtpd_tls_cert_file=/etc/letsencrypt/live/$maildomain/fullchain.pem"
 postconf -e "smtpd_use_tls = yes"
 postconf -e "smtpd_tls_auth_only = yes"
+postconf -e "smtp_tls_security_level = may"
+postconf -e "smtp_tls_loglevel = 1"
+postconf -e "smtp_tls_CAfile = /etc/letsencrypt/live/$maildomain/cert.pem"
 
 # Here we tell Postfix to look to Dovecot for authenticating users/passwords.
 # Dovecot will be putting an authentication socket in /var/spool/postfix/private/auth


### PR DESCRIPTION
This prevents sent emails from being marked as insecure in Gmail. 