### PR TITLE
Echo now is displaying horizontal tabs instead of \t

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -279,11 +279,11 @@ spfentry="@\\tTXT\\tv=spf1 mx a:$maildomain -all"
 
 useradd -m -G mail dmarc
 
-echo "$dkimentry
+echo -e "$dkimentry
 $dmarcentry
 $spfentry" > "$HOME/dns_emailwizard"
 
-echo "
+echo -e "
 
  _   _
 | \ | | _____      ___


### PR DESCRIPTION
After displaying the values to paste into the DNS echo doesn't use the `-e` option. This in effect creates the `~/dns_emailwizard` looking like this:

>.....\tTXT\tv=DKIM1....
> ....\tTXT\tv=DMARC1....
> @\tTXT\tv=spf1....

Now it's using it and writing the correct thing into the `dns_emailwizard` file.