### PR TITLE
Change Dovecot/Postfix definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ actually works perfectly.
 
 ## This script installs
 
-- **Postfix** to send mail.
-- **Dovecot** to receive mail.
+- **Postfix** to send and receive mail.
+- **Dovecot** to get mail to your email client (mutt, Thunderbird, etc).
 - Config files that unique the two above securely with native log-ins.
 - **Spamassassin** to prevent spam and allow you to make custom filters.
 - **OpenDKIM** to validate you so you can send to Gmail and other big sites.


### PR DESCRIPTION
Technically Postfix is responsible for sending *and* receiving mail between *your server and other SMTP servers* (Mail Transfer Agents). Dovecot is only so you can view your mail in email clients on your computer instead of server, which is not really *receiving*. You can have a perfectly functional email system with no IMAP/POP server at all, you'd just have to read your email over SSH or whatever