### PR TITLE
remove smtp_tls_CAfile from postfix main.cf

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -64,7 +64,6 @@ postconf -e "smtpd_use_tls = yes"
 postconf -e "smtpd_tls_auth_only = yes"
 postconf -e "smtp_tls_security_level = may"
 postconf -e "smtp_tls_loglevel = 1"
-postconf -e "smtp_tls_CAfile=$certdir/cert.pem"
 
 # Here we tell Postfix to look to Dovecot for authenticating users/passwords.
 # Dovecot will be putting an authentication socket in /var/spool/postfix/private/auth


### PR DESCRIPTION
I noticed the following line (line 75) in your script:

`postconf -e "smtp_tls_CAfile=$certdir/cert.pem"`

According to the [docs](http://www.postfix.org/postconf.5.html#smtp_tls_CAfile) this parameter specifies the CA file for the smtp client. If I understand this correctly, this means that with this setting in place you are effectively refusing connections from servers which don't use letsencrypt as CA.

I propose to remove the line in it's entirety, as the CA cert is already contained in the `fullchain.pem` cert.