### PR TITLE
Minor change for dovecot.conf to work on v2.3

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -125,6 +125,7 @@ echo "# Dovecot config
 ssl = required
 ssl_cert = <$certdir/fullchain.pem
 ssl_key = <$certdir/privkey.pem
+ssl_dh = </usr/share/dovecot/dh.pem
 # Plaintext login. This is safe and easy thanks to SSL.
 auth_mechanisms = plain login
 


### PR DESCRIPTION
According to the [Dovecot wiki](https://wiki.dovecot.org/SSL/DovecotConfiguration):-

> From version 2.3, you must specify path to DH parameters file using:
> ssl_dh=</path/to/dh.pem"
> 

This actually threw an error something along the lines of `imap-login: Error: Failed to initialize SSL`
when I updated my VPS to Debian Buster.