### PR TITLE
set dovecot ssl_dh based on version

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -114,12 +114,10 @@ spamassassin unix -     n       n       -       -       pipe
 # /etc/dovecot/dovecot.conf because it's easier to manage. You can get a backup
 # of the original in /usr/share/dovecot if you want.
 
-dovecot_v="$(dovecot --version | cut -d ' ' -f1 | cut -d '.' -f1-2)"
-dovecot_v_major=${dovecot_v%.*} 
-dovecot_v_minor=${dovecot_v#*.} 
+dovecot_v="$(dovecot --version | cut -d '.' -f1-2)"
 dovecot_dh="ssl_dh = </usr/share/dovecot/dh.pem"
 
-[ $dovecot_v_major -eq 2 ] && [ $dovecot_v_minor -lt 3 ] || [ $dovecot_v_major -lt 2 ] &&  dovecot_dh="#$dovecot_dh"
+[ ${dovecot_v%.*} -eq 2 ] && [ ${dovecot_v#*.} -lt 3 ] || [ ${dovecot_v%.*} -lt 2 ] && dovecot_dh="#$dovecot_dh"
 
 echo "Creating Dovecot config (v $dovecot_v)..."
 
@@ -134,8 +132,7 @@ echo "# Dovecot config
 ssl = required
 ssl_cert = <$certdir/fullchain.pem
 ssl_key = <$certdir/privkey.pem
-#You have to add ssl_dh if your Dovecot version is 2.3 or greater!
-#https://wiki.dovecot.org/SSL/DovecotConfiguration#SSL_security_settings
+# You have to add ssl_dh if your Dovecot version is 2.3 or greater!
 $dovecot_dh
 # Plaintext login. This is safe and easy thanks to SSL.
 auth_mechanisms = plain login

--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -114,7 +114,14 @@ spamassassin unix -     n       n       -       -       pipe
 # /etc/dovecot/dovecot.conf because it's easier to manage. You can get a backup
 # of the original in /usr/share/dovecot if you want.
 
-echo "Creating Dovecot config..."
+dovecot_v="$(dovecot --version | cut -d ' ' -f1 | cut -d '.' -f1-2)"
+dovecot_v_major=${dovecot_v%.*} 
+dovecot_v_minor=${dovecot_v#*.} 
+dovecot_dh="ssl_dh = </usr/share/dovecot/dh.pem"
+
+[ $dovecot_v_major -eq 2 ] && [ $dovecot_v_minor -lt 3 ] || [ $dovecot_v_major -lt 2 ] &&  dovecot_dh="#$dovecot_dh"
+
+echo "Creating Dovecot config (v $dovecot_v)..."
 
 echo "# Dovecot config
 # Note that in the dovecot conf, you can use:
@@ -127,7 +134,9 @@ echo "# Dovecot config
 ssl = required
 ssl_cert = <$certdir/fullchain.pem
 ssl_key = <$certdir/privkey.pem
-ssl_dh = </usr/share/dovecot/dh.pem
+#You have to add ssl_dh if your Dovecot version is 2.3 or greater!
+#https://wiki.dovecot.org/SSL/DovecotConfiguration#SSL_security_settings
+$dovecot_dh
 # Plaintext login. This is safe and easy thanks to SSL.
 auth_mechanisms = plain login
 

--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -117,7 +117,7 @@ spamassassin unix -     n       n       -       -       pipe
 dovecot_v="$(dovecot --version | cut -d '.' -f1-2)"
 dovecot_dh="ssl_dh = </usr/share/dovecot/dh.pem"
 
-[ ${dovecot_v%.*} -eq 2 ] && [ ${dovecot_v#*.} -lt 3 ] || [ ${dovecot_v%.*} -lt 2 ] && dovecot_dh="#$dovecot_dh"
+[ ${dovecot_v%.*} -eq 2 ] && [ ${dovecot_v#*.} -lt 3 ] || [ ${dovecot_v%.*} -lt 2 ] && dovecot_dh=""
 
 echo "Creating Dovecot config (v $dovecot_v)..."
 
@@ -132,7 +132,6 @@ echo "# Dovecot config
 ssl = required
 ssl_cert = <$certdir/fullchain.pem
 ssl_key = <$certdir/privkey.pem
-# You have to add ssl_dh if your Dovecot version is 2.3 or greater!
 $dovecot_dh
 # Plaintext login. This is safe and easy thanks to SSL.
 auth_mechanisms = plain login


### PR DESCRIPTION
Commit 755284ae3b9ffe3fc1dafe5dc39d10f97f62b6ac breaks compatibility with Dovecot versions older than 2.3. They don't recognize the `ssl_dh` parameter as valid, so it has to be removed (happened to me on ubuntu 18.04).
