### PR TITLE
Update emailwiz.sh

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -72,9 +72,7 @@ postconf -e "smtp_tls_mandatory_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1"
 postconf -e "smtpd_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1"
 postconf -e "smtp_tls_protocols = !SSLv2, !SSLv3, !TLSv1, !TLSv1.1"
 postconf -e "tls_preempt_cipherlist = yes"
-postconf -e "smtpd_tls_exclude_ciphers = aNULL, LOW, EXP, MEDIUM, ADH, AECDH, MD5,
-                            DSS, ECDSA, CAMELLIA128, 3DES, CAMELLIA256,
-                            RSA+AES, eNULL"
+postconf -e "smtpd_tls_exclude_ciphers = aNULL, LOW, EXP, MEDIUM, ADH, AECDH, MD5, DSS, ECDSA, CAMELLIA128, 3DES, CAMELLIA256, RSA+AES, eNULL"
 
 # Here we tell Postfix to look to Dovecot for authenticating users/passwords.
 # Dovecot will be putting an authentication socket in /var/spool/postfix/private/auth


### PR DESCRIPTION
Ubuntu can't run multiple lines without a special character, thus making the script malfunction, putting the commands on the same line solves the problem and the script can be used on Ubuntu 20.04