### PR TITLE
Update README.md -- After watching Landchad video

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,4 @@ support me at [lukesmith.xyz/donate](https://lukesmith.xyz/donate.html).
   [Vultr](https://www.vultr.com/docs/what-ports-are-blocked) for instance
   blocks this by default, you need to open a support ticket with them to open
   it. You can't send mail if 25 is blocked
+  - Alternatively you could use a service like [Sendgrid](https://sendgrid.com/) as a relay for your outgoing mail. These services usually offer 100 outgoing mails/day for free which should be plenty. This removes the need for opening port 25 and minimizes the risk of getting blacklisted and your mail landing in spam folders. To integrate Sendgrid with Postfix you can refer to [this guide](https://sendgrid.com/docs/for-developers/sending-email/postfix/).


### PR DESCRIPTION
## Context

Relaying outgoing email through Sendgrid or similar Email services massively reduces the risk of getting flagged as spam. It also removes the necessity to ask the support to open port 25 for you. They offer 100 mails for free per day which is plenty. You just need to add:
```
smtp_sasl_auth_enable = yes
smtp_sasl_password_maps = hash:/etc/postfix/sasl_passwd
smtp_sasl_security_options = noanonymous
smtp_sasl_tls_security_options = noanonymous
smtp_tls_security_level = encrypt
header_size_limit = 4096000
relayhost = [smtp.sendgrid.net]:587
```
to your `/etc/postfix/main.cf` and add the api key like this: `[smtp.sendgrid.net]:587 apikey:yourSendGridApiKey` to your `/etc/postfix/sasl_passwd`

Finally:
```
$ sudo chmod 600 /etc/postfix/sasl_passwd
$ sudo postmap /etc/postfix/sasl_passwd
$ sudo systemctl restart postfix
```

This is the [official guide](https://sendgrid.com/docs/for-developers/sending-email/postfix/) for this.