### PR TITLE
Disallow unauthenticated senders

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -81,6 +81,7 @@ postconf -e "smtpd_sasl_type = dovecot"
 postconf -e "smtpd_sasl_path = private/auth"
 
 # Sender and recipient restrictions
+postconf -e "smtpd_sender_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unknown_sender_domain, reject_unauth_pipelining, reject_non_fqdn_sender, reject_sender_login_mismatch, reject_authenticated_sender_login_mismatch, reject_known_sender_login_mismatch, reject_unauthenticated_sender_login_mismatch"
 postconf -e "smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unauth_destination"
 
 # NOTE: the trailing slash here, or for any directory name in the home_mailbox

--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -81,7 +81,7 @@ postconf -e "smtpd_sasl_type = dovecot"
 postconf -e "smtpd_sasl_path = private/auth"
 
 # Sender and recipient restrictions
-postconf -e "smtpd_sender_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unknown_sender_domain, reject_unauth_pipelining, reject_non_fqdn_sender, reject_sender_login_mismatch, reject_authenticated_sender_login_mismatch, reject_known_sender_login_mismatch, reject_unauthenticated_sender_login_mismatch"
+postconf -e "smtpd_sender_restrictions = permit_sasl_authenticated, reject_unknown_sender_domain, reject_unauth_pipelining, reject_non_fqdn_sender, reject_sender_login_mismatch, reject_authenticated_sender_login_mismatch, reject_known_sender_login_mismatch, reject_unauthenticated_sender_login_mismatch"
 postconf -e "smtpd_recipient_restrictions = permit_sasl_authenticated, permit_mynetworks, reject_unauth_destination"
 
 # NOTE: the trailing slash here, or for any directory name in the home_mailbox


### PR DESCRIPTION
This stops unauthenticated users from sending unauthorized emails.

Example:

`swaks -t test@example.com -f matteo@mail.saloniamatteo.top --header "Subject: Unauthorized Email" --body "This email should not go through." --server mail.saloniamatteo.top`

Before this patch, any user could run the command above, without any authentication, and the server would gladly accept the incoming mail.
Now, the email is rejected, and the email server only allows authenticated users.

Output of the command above:

```
=== Trying mail.saloniamatteo.top:25...
=== Connected to mail.saloniamatteo.top.
<-  220 mail.saloniamatteo.top ESMTP Postfix
 -> EHLO artix.localdomain
<-  250-mail.saloniamatteo.top
<-  250-PIPELINING
<-  250-SIZE 10240000
<-  250-VRFY
<-  250-ETRN
<-  250-STARTTLS
<-  250-ENHANCEDSTATUSCODES
<-  250-8BITMIME
<-  250-DSN
<-  250-SMTPUTF8
<-  250 CHUNKING
 -> MAIL FROM:<matteo@mail.saloniamatteo.top>
<-  250 2.1.0 Ok
 -> RCPT TO:<test@example.com>
<** 554 5.7.1 <test@example.com>: Relay access denied
 -> QUIT
<-  221 2.0.0 Bye
=== Connection closed with remote host.
```

Important Note: you MUST set `mydestination` to `$myhostname`, otherwise your email server is going to accept any unauthorized email.