### PR TITLE
Fix: Opendkim won't start: can't open PID file?

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -278,6 +278,10 @@ postconf -e "smtpd_milters = inet:localhost:12301"
 postconf -e "non_smtpd_milters = inet:localhost:12301"
 postconf -e "mailbox_command = /usr/lib/dovecot/deliver"
 
+# A fix for "Opendkim won't start: can't open PID file?", as specified here: https://serverfault.com/a/847442
+/lib/opendkim/opendkim.service.generate
+systemctl daemon-reload
+
 for x in spamassassin opendkim dovecot postfix; do
 	printf "Restarting %s..." "$x"
 	service "$x" restart && printf " ...done\\n"


### PR DESCRIPTION
After following your youtube video completely on fresh install of Debian 10 hosted on vultr, i could not get DKIM to pass with appmaildev.com.

After checking systemctl I've seen:
`
systemd[1]: Starting OpenDKIM DomainKeys Identified Mail (DKIM) Milter...
systemd[1]: opendkim.service: Can't open PID file /var/run/opendkim/opendkim.pid (yet?) after start: No such file or directory
opendkim[8226]: OpenDKIM Filter v2.11.0 starting (args: -x /etc/opendkim.conf)
systemd[1]: opendkim.service: Start operation timed out. Terminating.
`

After a long internet searching i noticed that a lot of people experienced the same issue. After trying a few fixes with no avail, i stumbled upon [this](https://serverfault.com/a/847442), which solves the issue perfectly with a script that's provided with a opendkim package. It's seems that the issue is not fixed in the package itself yet.

Hope this helps someone 