### PR TITLE
use domain instead of @

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -293,7 +293,7 @@ service ufw stop
 pval="$(tr -d "\n" </etc/postfix/dkim/$subdom.txt | sed "s/k=rsa.* \"p=/k=rsa; p=/;s/\"\s*\"//;s/\"\s*).*//" | grep -o "p=.*")"
 dkimentry="$subdom._domainkey.$domain	TXT	v=DKIM1; k=rsa; $pval"
 dmarcentry="_dmarc.$domain	TXT	v=DMARC1; p=reject; rua=mailto:dmarc@$domain; fo=1"
-spfentry="@	TXT	v=spf1 mx a:$maildomain -all"
+spfentry="$domain	TXT	v=spf1 mx a:$maildomain -all"
 
 useradd -m -G mail dmarc
 


### PR DESCRIPTION
I had a problem inserting the spf1 entry on my DNS provider. It couldn't parse the @. Just inserting it with my domain as key worked, so I guess @ is just an alias for 'current domain'. Therefore wouldn't be using the domain instead of @ in the script be more general?