### PR TITLE
Fix: #178 leakage of public IP addresses in sent emails

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -99,6 +99,14 @@ postconf -e "smtpd_recipient_restrictions = permit_sasl_authenticated, permit_my
 # boomers want and no one else).
 postconf -e "home_mailbox = Mail/Inbox/"
 
+# A fix referenced in issue #178 - Postfix configuration leaks ip addresses (https://github.com/LukeSmithxyz/emailwiz/issues/178)
+# Prevent "Received From:" header in sent emails in order to prevent leakage of public ip addresses
+postconf -e "header_checks = regexp:/etc/postfix/header_checks"
+
+# strips "Received From:" in sent emails
+echo "/^Received:.*/     IGNORE
+/^X-Originating-IP:/    IGNORE" >> /etc/postfix/header_checks
+
 # master.cf
 echo "Configuring Postfix's master.cf..."
 


### PR DESCRIPTION
This is a fix for the issue #178 regarding IP address leakage.
I decided to open this pull request because the issue opener hasn't opened one already, and this issue thread seems to have been dormant for some time.

These changes applied to my current email server, and I have not encountered issues yet (Running Debian 11 Stable).
I have double checked the `postconf` man page too, just to make sure that want was said in the source comments was accurate and so that I wasn't doing something stupid.