### PR TITLE
 Change the documentation: IMAP port: 993 didn't work, but works on t…

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,17 @@ to log in remotely though:
 Let's say you want to access your mail with Thunderbird or mutt or another
 email program. For my domain, the server information will be as follows:
 
+### SMTP
 - SMTP server: `mail.lukesmith.xyz`
 - SMTP port: 587
+- Authentication Method: Normal password
+- Connection Security: STARTTLS
+
+### IMAP
 - IMAP server: `mail.lukesmith.xyz`
-- IMAP port: 993
+- IMAP port: 143
+- Authentication Method: Normal password
+- Connection Security: STARTTLS
 
 In previous versions of emailwiz, you also had to log on with *only* your
 username (i.e. `luke`) rather than your whole email address (i.e.


### PR DESCRIPTION
…he default IMAP port: 143. Adding more useful information.

The correct IMAP port: 993 didn't work, I've already checked if the port is open or not with netcat and indeed it is. Although it works with the default port (143). I suggest changing the README.md documentation on (on line 104) to the correct ports. Alternatively, you can set up the email server to set the IMAP port to 993. On another note, some Applications don't default the connection security to STARTTLS.

On K-9 Mail (Android) I had to tinker for a while before I ended up with the correct information. In the case of Thunderbird, it does automatically set the ports, etc. It's better to have this on the documentation for easy user setup, just to make sure.