### PR TITLE
Add spamassassin start and enable at boot.

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -309,8 +309,7 @@ for x in spamassassin opendkim dovecot postfix; do
 	service "$x" restart && printf " ...done\\n"
 done
 
-# Start the SpamAssassin process, and ensure SpamAssassin starts on boot.
-/etc/init.d/spamassassin start
+# Ensure SpamAssassin starts on boot.
 systemctl enable spamassassin.service
 
 # If ufw is used, enable the mail ports.

--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -309,6 +309,10 @@ for x in spamassassin opendkim dovecot postfix; do
 	service "$x" restart && printf " ...done\\n"
 done
 
+# Start the SpamAssassin process, and ensure SpamAssassin starts on boot.
+/etc/init.d/spamassassin start
+systemctl enable spamassassin.service
+
 # If ufw is used, enable the mail ports.
 pgrep ufw >/dev/null && { ufw allow 993; ufw allow 465 ; ufw allow 587; ufw allow 25 ;}
 


### PR DESCRIPTION
In Debian 11, the _spamassassin_ process does not appear to start after boot, so I included the _debian_/_ubuntu_ generic command to (hopefully) ensure this is done.  Perhaps I missed something, but I don't think this was explicitly handled otherwise. 

I only make this alteration because the issue occurred on my own use of the script.  I figure I may not be the only one.  I am no fan of, or expert in, _systemd_, so this may be incorrect in approach or use.