### PR TITLE
Only call deploy hook when mail cert is renewed

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -322,7 +322,7 @@ useradd -m -G mail dmarc
 
 grep -q '^deploy-hook = echo "$RENEWED_DOMAINS" | grep -q' /etc/letsencrypt/cli.ini ||
 	echo "
-deploy-hook = echo "\$RENEWED_DOMAINS" | grep -q \"$maildomain\" && service postfix reload && service dovecot reload" >> /etc/letsencrypt/cli.ini
+deploy-hook = echo "\$RENEWED_DOMAINS" | grep -q \"$maildomain\"" && service postfix reload && service dovecot reload" >> /etc/letsencrypt/cli.ini
 
 echo "$dkimentry
 $dmarcentry

--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -322,7 +322,7 @@ useradd -m -G mail dmarc
 
 grep -q '^deploy-hook = echo "$RENEWED_DOMAINS" | grep -q' /etc/letsencrypt/cli.ini ||
 	echo "
-deploy-hook = echo "\$RENEWED_DOMAINS" | grep -q \"$maildomain\"" && service postfix reload && service dovecot reload" >> /etc/letsencrypt/cli.ini
+deploy-hook = echo \"\$RENEWED_DOMAINS\" | grep -q '$maildomain' && service postfix reload && service dovecot reload" >> /etc/letsencrypt/cli.ini
 
 echo "$dkimentry
 $dmarcentry

--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -322,7 +322,7 @@ useradd -m -G mail dmarc
 
 grep -q '^deploy-hook = echo "$RENEWED_DOMAINS" | grep -q' /etc/letsencrypt/cli.ini ||
 	echo "
-deploy-hook = echo "$RENEWED_DOMAINS" | grep -q "$maildomain" && service postfix reload && service dovecot reload" >> /etc/letsencrypt/cli.ini
+deploy-hook = echo "\$RENEWED_DOMAINS" | grep -q \"$maildomain\" && service postfix reload && service dovecot reload" >> /etc/letsencrypt/cli.ini
 
 echo "$dkimentry
 $dmarcentry

--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -320,9 +320,9 @@ spfentry="$domain	TXT	v=spf1 mx a:$maildomain -all"
 
 useradd -m -G mail dmarc
 
-grep -q "^deploy-hook = postfix reload" /etc/letsencrypt/cli.ini ||
+grep -q '^deploy-hook = echo "$RENEWED_DOMAINS" | grep -q' /etc/letsencrypt/cli.ini ||
 	echo "
-deploy-hook = service postfix reload && service dovecot reload" >> /etc/letsencrypt/cli.ini
+deploy-hook = echo "$RENEWED_DOMAINS" | grep -q "$maildomain" && service postfix reload && service dovecot reload" >> /etc/letsencrypt/cli.ini
 
 echo "$dkimentry
 $dmarcentry


### PR DESCRIPTION
By default the deploy hook runs when any certificate is renewed, with these changes the hook only runs when the mail cert is renewed