### PR TITLE
Use single-quotes to prevent interpolation when configuring Postfix

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -57,7 +57,7 @@ echo "Configuring Postfix's main.cf..."
 postconf -e "myhostname = $maildomain"
 postconf -e "mail_name = $domain"  #This is for the smtpd_banner
 postconf -e "mydomain = $domain"
-postconf -e "mydestination = $myhostname, $mydomain, mail, localhost.localdomain, localhost, localhost.$mydomain"
+postconf -e 'mydestination = $myhostname, $mydomain, mail, localhost.localdomain, localhost, localhost.$mydomain'
 
 # Change the cert/key files to the default locations of the Let's Encrypt cert/key
 postconf -e "smtpd_tls_key_file=$certdir/privkey.pem"


### PR DESCRIPTION
Unless you intend to interpolate, you should never use double-quotes. In this instance, it was actually impactful -- `$myhostname` and `$mydomain` were meant to be left as-is, referring to those Postfix config parameters, but were accidentally interpolated and subsequently generating nonsense (but not fatal) configuration.

The generated config would look like this:
`mydestination = , , mail, localhost.localdomain, localhost, localhost.`
instead of:
`mydestination = $myhostname, $mydomain, mail, localhost.localdomain, localhost, localhost.$mydomain`