### PR TITLE
Make it work with Debian 12: spamassassin -> spamd

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -318,9 +318,23 @@ enabled = true
 enabled = true" > /etc/fail2ban/jail.d/emailwiz.local
 
 # Enable SpamAssassin update cronjob.
-sed -i "s|^CRON=0|CRON=1|" /etc/default/spamassassin
+if [ -f /etc/default/spamassassin ]
+then
+	sed -i "s|^CRON=0|CRON=1|" /etc/default/spamassassin
+	printf "Restarting spamassassin..."
+	service spamassassin restart && printf " ...done\\n"
+	systemctl enable spamassassin
+elif [ -f /etc/default/spamd ]
+then
+	sed -i "s|^CRON=0|CRON=1|" /etc/default/spamd
+	printf "Restarting spamd..."
+	service spamd restart && printf " ...done\\n"
+	systemctl enable spamd
+else
+	printf "!!! Neither /etc/default/spamassassin or /etc/default/spamd exists, this is unexpected and needs to be investigated"
+fi
 
-for x in spamassassin opendkim dovecot postfix fail2ban; do
+for x in opendkim dovecot postfix fail2ban; do
 	printf "Restarting %s..." "$x"
 	service "$x" restart && printf " ...done\\n"
 	systemctl enable "$x"


### PR DESCRIPTION
This commits checks for /etc/default/spamassassin. If it exists, it's passed through sed to modify the CRON variable as usual, and spamassassin.service is enabled and restarted.

If /etc/default/spamassassin does not exist, but /etc/default/spamd exists, we modify /etc/default/spamd instead, and restart and enable spamd.service.

This has to be done because Debian 12 introduced this breaking change: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1020859

This commit fixes #282 