### PR TITLE
Short-term workaround to prevent SMTP smuggling

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -308,9 +308,9 @@ postconf -e 'smtpd_milters = inet:localhost:12301'
 postconf -e 'non_smtpd_milters = inet:localhost:12301'
 postconf -e 'mailbox_command = /usr/lib/dovecot/deliver'
 
-# Short-term workaround to prevent SMTP smuggling
-postconf -e 'smtpd_forbid_unauth_pipelining = yes'
-postconf -e 'smtpd_discard_ehlo_keywords = chunking'
+# Long-term fix to prevent SMTP smuggling
+postconf -e 'smtpd_forbid_bare_newline = normalize'
+postconf -e 'smtpd_forbid_bare_newline_exclusions = $mynetworks'
 
 # A fix for "Opendkim won't start: can't open PID file?", as specified here: https://serverfault.com/a/847442
 /lib/opendkim/opendkim.service.generate

--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -308,6 +308,10 @@ postconf -e 'smtpd_milters = inet:localhost:12301'
 postconf -e 'non_smtpd_milters = inet:localhost:12301'
 postconf -e 'mailbox_command = /usr/lib/dovecot/deliver'
 
+# Short-term workaround to prevent SMTP smuggling
+postconf -e 'smtpd_forbid_unauth_pipelining = yes'
+postconf -e 'smtpd_discard_ehlo_keywords = chunking'
+
 # A fix for "Opendkim won't start: can't open PID file?", as specified here: https://serverfault.com/a/847442
 /lib/opendkim/opendkim.service.generate
 systemctl daemon-reload


### PR DESCRIPTION
Following the recent [disclosure of the SMTP smuggling 0-day vulnerability in Postfix](https://www.postfix.org/smtp-smuggling.html), this pull request applies the suggested short-term workaround from the linked blog post. This fix (currently) only works with Postfix 3.7.(>=6), which is currently packaged by Debian bookworm (i.e., no Ubuntu, no Debian bullseye) so it might be beneficial to also add a notice in the `README.md` for manual intervention.