### PR TITLE
Add safeguards to script

### DIFF
--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -347,10 +347,14 @@ for x in opendkim dovecot postfix fail2ban; do
 	systemctl enable "$x"
 done
 
+# In some cases, big name email services favor an spf record with certain mechanisms included.
+# See http://www.open-spf.org/SPF_Record_Syntax
+mailip=ip4:$(ping -c 1 $domain | grep -m1 -Eo '([0-9]+\.){3}[0-9]+')
+
 pval="$(tr -d '\n' <"/etc/postfix/dkim/$domain/$subdom.txt" | sed "s/k=rsa.* \"p=/k=rsa; p=/;s/\"\s*\"//;s/\"\s*).*//" | grep -o 'p=.*')"
 dkimentry="$subdom._domainkey.$domain	TXT	v=DKIM1; k=rsa; $pval"
 dmarcentry="_dmarc.$domain	TXT	v=DMARC1; p=reject; rua=mailto:dmarc@$domain; fo=1"
-spfentry="$domain	TXT	v=spf1 mx a:$maildomain -all"
+spfentry="$domain	TXT	v=spf1 mx a:$maildomain ip4:$mailip -all"
 mxentry="$domain	MX	10	$maildomain	300"
 
 useradd -m -G mail dmarc

--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -349,7 +349,7 @@ done
 
 # In some cases, big name email services favor an spf record with certain mechanisms included.
 # See http://www.open-spf.org/SPF_Record_Syntax
-mailip=ip4:$(ping -c 1 $domain | grep -m1 -Eo '([0-9]+\.){3}[0-9]+')
+mailip=$(ping -c 1 $domain | grep -m1 -Eo '([0-9]+\.){3}[0-9]+')
 
 pval="$(tr -d '\n' <"/etc/postfix/dkim/$domain/$subdom.txt" | sed "s/k=rsa.* \"p=/k=rsa; p=/;s/\"\s*\"//;s/\"\s*).*//" | grep -o 'p=.*')"
 dkimentry="$subdom._domainkey.$domain	TXT	v=DKIM1; k=rsa; $pval"

--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -25,9 +25,9 @@ certdir="/etc/letsencrypt/live/$maildomain"
 
 # Preliminary record checks
 ipv4=$(host "$domain" | grep -m1 -Eo '([0-9]+\.){3}[0-9]+')
-[ -z "$ipv4" ] && echo "\033[0;31mPlease point your domain ("$domain") to your server's ipv4 address."
+[ -z "$ipv4" ] && echo "\033[0;31mPlease point your domain ("$domain") to your server's ipv4 address." && exit 1
 ipv6=$(host "$domain" | grep "IPv6" | awk '{print $NF}')
-[ -z "$ipv6" ] && echo "\033[0;31mPlease point your domain ("$domain") to your server's ipv6 address."
+[ -z "$ipv6" ] && echo "\033[0;31mPlease point your domain ("$domain") to your server's ipv6 address." && exit 1
 
 # Open required mail ports, and 80, for Certbot.
 for port in 80 993 465 25 587; do

--- a/emailwiz.sh
+++ b/emailwiz.sh
@@ -23,6 +23,12 @@ subdom=${MAIL_SUBDOM:-mail}
 maildomain="$subdom.$domain"
 certdir="/etc/letsencrypt/live/$maildomain"
 
+# Preliminary record checks
+ipv4=$(host "$domain" | grep -m1 -Eo '([0-9]+\.){3}[0-9]+')
+[ -z "$ipv4" ] && echo "\033[0;31mPlease point your domain ("$domain") to your server's ipv4 address."
+ipv6=$(host "$domain" | grep "IPv6" | awk '{print $NF}')
+[ -z "$ipv6" ] && echo "\033[0;31mPlease point your domain ("$domain") to your server's ipv6 address."
+
 # Open required mail ports, and 80, for Certbot.
 for port in 80 993 465 25 587; do
 	ufw allow "$port" 2>/dev/null
@@ -347,14 +353,10 @@ for x in opendkim dovecot postfix fail2ban; do
 	systemctl enable "$x"
 done
 
-# Generate spf mechanisms
-mailip4=$(host "$domain" | grep -m1 -Eo '([0-9]+\.){3}[0-9]+')
-mailip6=$(host "$domain" | grep "IPv6" | awk '{print $NF}')
-
 pval="$(tr -d '\n' <"/etc/postfix/dkim/$domain/$subdom.txt" | sed "s/k=rsa.* \"p=/k=rsa; p=/;s/\"\s*\"//;s/\"\s*).*//" | grep -o 'p=.*')"
 dkimentry="$subdom._domainkey.$domain	TXT	v=DKIM1; k=rsa; $pval"
 dmarcentry="_dmarc.$domain	TXT	v=DMARC1; p=reject; rua=mailto:dmarc@$domain; fo=1"
-spfentry="$domain	TXT	v=spf1 mx a:$maildomain ip4:$mailip4 ip6:$mailip6 -all"
+spfentry="$domain	TXT	v=spf1 mx a:$maildomain ip4:$ipv4 ip6:$ipv6 -all"
 mxentry="$domain	MX	10	$maildomain	300"
 
 useradd -m -G mail dmarc


### PR DESCRIPTION
> DNS records that point at least your domain's mail. subdomain to your server's IP (IPv4 **and** IPv6). This is required on initial run for certbot to get an SSL certificate for your mail. subdomain.

Someone can forget to setup their AAAA record and the script will still appear to work (certbot doesn't need ipv6). This pr adds a safeguard to include ipv4 and ipv6 into the spf record. Martin [found](https://github.com/LukeSmithxyz/landchad/pull/298) by adding it he could send to gmail even without the AAAA record.

I guess what's happening here is some people are not watching the video tutorial so they skip over adding AAAA record since it's not explicitly stated to do so in the text based guides.